### PR TITLE
Added largeHeap declaration

### DIFF
--- a/templates/AndroidManifest.tmpl.xml
+++ b/templates/AndroidManifest.tmpl.xml
@@ -11,6 +11,7 @@
                android:allowBackup="true"
                android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
                android:hardwareAccelerated="true"
+               android:largeHeap="true"
                >
 
     <meta-data android:name="wakelock" android:value="1" />

--- a/templates/AndroidManifest.tmpl.xml
+++ b/templates/AndroidManifest.tmpl.xml
@@ -10,7 +10,7 @@
                android:icon="@drawable/icon"
                android:allowBackup="true"
                android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-               android:hardwareAccelerated="true" >
+               android:hardwareAccelerated="true"
                >
 
     <meta-data android:name="wakelock" android:value="1" />


### PR DESCRIPTION
The android:largeHeap declaration allows applications to use a larger Dalvik heap.
Its use is discouraged except where necessary, so I'll understand if you reject this PR based on that premise.
However, in my testing it has improved performance for higher-res (720p+) Renpy games, which otherwise lag on modern-ish hardware.
