### PR TITLE
Catch errors when checking for OpenJDK 8

### DIFF
--- a/buildlib/rapt/install_sdk.py
+++ b/buildlib/rapt/install_sdk.py
@@ -32,7 +32,10 @@ def run_slow(interface, *args, **kwargs):
     be cancelled.
     """
 
-    interface.call(args, cancel=True, **kwargs)
+    try:
+        interface.call(args, cancel=True, **kwargs)
+    except (subprocess.CalledProcessError, OSError):
+        return False
     return True
 
 
@@ -48,7 +51,7 @@ def check_java(interface):
         interface.fail(__("I was unable to use javac to compile a test file. If you haven't installed the Java Development Kit yet, please download it from:\n\nhttp://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html\n\nThe JDK is different from the JRE, so it's possible you have Java without having the JDK. Without a working JDK, I can't continue."))
 
     if not run_slow(interface, plat.java, "-classpath", plat.path("buildlib"), "CheckJDK8", use_path=True):
-        interface.fail(__("The version of Java on your computer does not appear to be JDK 8, which is the only version supported by the Android SDK. If you need to install JDK 8, you can download it from:\n\nhttp://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html\n\nYou can also set the JAVA_HOME environment variabe to use a different version of Java."))
+        interface.fail(__("The version of Java on your computer does not appear to be JDK 8, which is the only version supported by the Android SDK. If you need to install JDK 8, you can download it from:\n\nhttp://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html\n\nYou can also set the JAVA_HOME environment variable to use a different version of Java."))
 
     interface.success(__("The JDK is present and working. Good!"))
 

--- a/buildlib/rapt/interface.py
+++ b/buildlib/rapt/interface.py
@@ -207,7 +207,7 @@ class Interface(object):
 
     def call(self, args, cancel=False, use_path=False, yes=False):
         """
-        Executes `args` as a program. Raises subprocess.CalledProgramError
+        Executes `args` as a program. Raises subprocess.CalledProcessError
         if the program fails.
 
         `cancel`


### PR DESCRIPTION
This avoids getting the cryptic Ren'Py Exception screen ;)