### PR TITLE
X86 fixes

### DIFF
--- a/native/build.sh
+++ b/native/build.sh
@@ -121,21 +121,18 @@ build_arm64 () {
 # ARM64 uses OPENSSL_ARCH="linux-generic64 -DB_ENDIAN"
 
 
-# x86 FFMPEG doesn't work on modern android, and neither side wants to
-# do the work to fix it. So we'll drop support.
+build_x86 () {
 
-# build_x86 () {
-#
-#     export ANDROID_PLATFORM=android-15
-#     export PLATFORM=x86
-#     export NDK_ARCH=x86
-#     export FFMPEG_ARCH=x86
-#     export GCC_ARCH=i686-linux-android
-#     export OPENSSL_ARCH="android-x86"
-#     export PICFLAG="-fPIC"
-#
-#     build_platform
-# }
+    export ANDROID_PLATFORM=android-21
+    export PLATFORM=x86
+    export NDK_ARCH=x86
+    export FFMPEG_ARCH=x86
+    export GCC_ARCH=i686-linux-android
+    export OPENSSL_ARCH="linux-generic32"
+    export PICFLAG="-fPIC"
+
+    build_platform
+}
 
 build_x86_64 () {
 
@@ -158,10 +155,11 @@ build_ () {
 
     build_arm64
     build_arm
+    build_x86
     build_x86_64
 
     export ANDROID_PLATFORM=android-21
-    export ALL_PLATFORMS="armeabi-v7a x86_64 arm64-v8a"
+    export ALL_PLATFORMS="armeabi-v7a x86_64 x86 arm64-v8a"
 
     run jni all
     run finish dist

--- a/native/scripts/ffmpeg.sh
+++ b/native/scripts/ffmpeg.sh
@@ -21,6 +21,7 @@ build () {
        --extra-ldflags="$LDFLAGS" \
        --extra-ldexeflags=-pie \
        --enable-cross-compile \
+       --disable-asm \
        --disable-shared \
        --enable-pic \
        --enable-static \

--- a/native/scripts/ffmpeg.sh
+++ b/native/scripts/ffmpeg.sh
@@ -12,6 +12,13 @@ build () {
 
     pushd "ffmpeg-$version"
 
+    if [ "$FFMPEG_ARCH" = "x86" ]; then
+        FFMPEG_FLAGS="--disable-asm";
+    else
+        FFMPEG_FLAGS="";
+    fi;
+      
+
     ./configure --prefix="$INSTALLDIR" \
        --cc="$CC" \
        --ld="$CC" \
@@ -21,7 +28,7 @@ build () {
        --extra-ldflags="$LDFLAGS" \
        --extra-ldexeflags=-pie \
        --enable-cross-compile \
-       --disable-asm \
+       $FFMPEG_FLAGS \
        --disable-shared \
        --enable-pic \
        --enable-static \

--- a/templates/app-build.gradle
+++ b/templates/app-build.gradle
@@ -23,7 +23,7 @@ android {
             enable true;
             reset();
 
-            include "x86_64", "armeabi-v7a", "arm64-v8a"
+            include "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
             universalApk true
         }
     }
@@ -44,7 +44,7 @@ android {
         }
     }
 
-    project.ext.versionCodes = ['armeabi-v7a': 0, 'arm64-v8a': 1, 'x86_64': 8]
+    project.ext.versionCodes = ['armeabi-v7a': 0, 'arm64-v8a': 1, 'x86': 4, 'x86_64': 8]
 
     android.applicationVariants.all { variant ->
         // assign different version code for each output


### PR DESCRIPTION
FFmpeg build on Android x86 is broken because of text relocation problem.
The error lies somewhere in the ASM code, so '--disable-asm' fixes the issue.
It's not the best solution as it produces "slow" binary, but that doesn't seem to be very affecting (at least on the games I've tried it) and of course better than producing no build at all for x86.
Hense the proposed pull.